### PR TITLE
Makefile: make build target phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-
+.PHONY: build
 build:
 	echo "Build successful"


### PR DESCRIPTION
As the build target does not create a file with that name, it should be
marked as phony.